### PR TITLE
docs(github): refine Chinese templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,43 +1,44 @@
-name: "\U0001F41E Bug report"
-description: Report an issue with this template
+name: "\U0001F41E 缺陷报告"
+description: 反馈模板中的问题
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report! **Before you start, make sure you have the latest versions of the packages you're using.**
+        感谢你愿意提交缺陷报告！**请先确认使用的是最新版本的依赖与模板。**
   - type: textarea
     id: bug-description
     attributes:
-      label: Describe the bug
-      description: If you intend to submit a PR for this issue, tell us in the description. Thanks!
-      placeholder: Bug description
+      label: 缺陷描述
+      description: 如果你计划提交 PR，请在这里说明。谢谢！
+      placeholder: 简要描述遇到的问题
     validations:
       required: true
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction
-      description: A link to a repository, or text descriptions, that reproduces the issue. Reproductions must be [short, self-contained and correct](http://sscce.org/) and must not contain files or code that aren't relevant to the issue — please do NOT just paste a link to your project. Explaining how to reproduce is generally not enough. It pushes the burden of creating a reproduction project onto a small set of volunteer maintainers and isn't scalable. If no reproduction is provided, the issue will be closed.
-      placeholder: Reproduction
+      label: 复现方式
+      description: 请提供可复现问题的最小示例或仓库链接。复现需 [短小、可独立运行且正确](http://sscce.org/)，不要只贴完整项目链接或无关代码。仅描述步骤而无复现往往会增加维护成本，且可能被关闭。
+      placeholder: 复现仓库地址或最小代码示例
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: Logs
-      description: Please include browser console and server logs around the time this bug occurred. Please try not to insert an image but copy paste the log text.
+      label: 日志
+      description: 请贴出出错前后的浏览器控制台或服务端日志，优先使用文本而非截图。
       render: Shell
   - type: dropdown
     id: severity
     attributes:
-      label: Severity
+      label: 严重程度
       options:
-        - annoyance
-        - serious, but I can work around it
-        - blocking all usage of this template
+        - 轻微影响（可忽略）
+        - 影响明显（仍有绕过方案）
+        - 完全阻断（无法继续）
     validations:
       required: true
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Information
+      label: 补充信息
+      description: 任何有助于定位问题的上下文（环境、版本、截图等）。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,2 @@
+# 是否允许空白 Issue
 blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,44 +1,44 @@
-name: 'Feature Request'
-description: Suggest an idea for this project
+name: "功能需求"
+description: 提出想法或改进建议
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to request this feature! If your feature request is complex or substantial enough to warrant in-depth discussion, maintainers may close the issue and ask you to open an RFC.
+        感谢你的建议！如果需求较复杂或影响范围较大，维护者可能会请你先发起 RFC 进行深入讨论。
   - type: textarea
     id: problem
     attributes:
-      label: Problem
-      description: Please provide a clear and concise description the problem this feature would solve. The more information you can provide here, the better.
-      placeholder: I'm always frustrated when...
+      label: 目标问题
+      description: 请清晰描述该功能要解决的问题。
+      placeholder: 我经常遇到的问题是...
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
-      label: Solution
-      description: Please provide a clear and concise description of what you would like to happen.
-      placeholder: I would like to see...
+      label: 期望方案
+      description: 你希望这个模板如何改进？
+      placeholder: 我希望增加/改成...
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives
-      description: Please provide a clear and concise description of any alternative solutions or features you've considered.
+      label: 备选方案
+      description: 如果你考虑过其他解决方案，请在这里说明。
   - type: dropdown
     id: importance
     attributes:
-      label: Importance
-      description: How important is this feature to you?
+      label: 重要程度
+      description: 这个功能对你有多重要？
       options:
-        - nice to have
-        - would make my life easier
-        - i cannot use this template without it
+        - 可有可无
+        - 会明显提高效率
+        - 没有它就无法使用
     validations:
       required: true
   - type: textarea
     id: additional-context
     attributes:
-      label: Additional Information
-      description: Add any other context or screenshots about the feature request here.
+      label: 补充信息
+      description: 其他背景、截图或参考资料。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,22 @@
-<!-- Your PR description here -->
+<!-- 在这里填写 PR 说明 -->
 
 ---
 
-### Please don't delete this checklist! Before submitting the PR, please make sure you do the following
+### 请不要删除此清单！（请勿删除）提交前请确认以下事项
 
-- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC.
-- [ ] This message body should clearly illustrate what problems it solves.
-- [ ] Ideally, include a test that fails without this PR but passes with it.
+- [ ] PR 已关联对应 Issue 或已有讨论；大型变更请先发起 RFC。
+- [ ] 描述清楚解决的问题与影响范围。
+- [ ] 理想情况下包含一个在未合入前失败、合入后通过的测试。
 
 ### Tests
 
-- [ ] Run the tests and other checks with `pnpm ci`
+- [ ] 已运行 `bun run ci`（lint → typecheck → test → build → check:exports）
 
 ### Changesets
 
-- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features and fix bugs should all be `patch` before we release `0.1.0`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
+- [ ] 如果变更需要记录在变更日志中，请运行 `bunx changeset add` 并按提示生成变更集。
+- [ ] 在 `0.1.0` 发布前，新增功能与修复建议使用 `patch` 类型，并在说明中使用 `feat:` / `fix:` / `chore:` 前缀。
 
 ### Edits
 
-- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
+- [ ] 已勾选 "Allow edits from maintainers"，以便维护者协助修改。

--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   release:
     name: create-release-pr
+    # 仅在 CI 成功且事件为 push 时创建发布 PR。
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     concurrency:
@@ -22,9 +23,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          # 拉取完整 Git 历史，方便 Changesets 生成变更日志。
           fetch-depth: 0
-          # 精确绑定到本次 CI 的执行分支，避免竞态
+          # 精确绑定到本次 CI 的执行分支，避免竞态。
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,26 @@
 env:
   HUSKY: 0
 name: CI
-# 指定工作流程应在何时运行。在这种情况下，它在 PR 和 Push 到 main 分支时运行。
+# 指定工作流程触发条件：PR 与 push 到 main 分支。
 on:
   pull_request:
   push:
     branches:
       - main
-# 使用 `cancel-in-progress` 防止多个工作流程实例同时运行，并取消任何现有的运行。
+# 使用 cancel-in-progress 避免重复执行，并取消旧的运行。
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-# 是一组要运行的作业。在本例中，我们有一个名为 ci 的作业。
+# 定义作业列表。当前只有一个名为 ci 的作业。
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      # 从仓库中检出代码。
+      # 检出代码。
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          # 拉取完整 Git 历史，方便 Changesets 生成变更日志。
           fetch-depth: 0
       # - name: Cache dependencies
       #   uses: actions/cache@v3
@@ -30,7 +30,6 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-bun-
       # - name: Use Node.js
-      #   # 设置 Node.js 和 npm。
       #   uses: actions/setup-node@v4
       #   with:
       #     node-version: "20"
@@ -41,5 +40,5 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run CI
-        # 运行项目的CI脚本。
+        # 执行项目的 CI 脚本。
         run: bun run ci

--- a/README.md
+++ b/README.md
@@ -1,38 +1,40 @@
 # create-npm-package
 
-一个用于快速搭建 npm 包的工程模板，内置 TypeScript、打包、测试、提交规范、发布流程等最佳实践，开箱即用。
+一个用于快速搭建 npm 包的工程模板，内置 TypeScript、打包、测试、提交规范与发布流程等最佳实践，开箱即用。
 
-## 贡献指南
+## 这是什么
 
-请阅读 [Repository Guidelines](AGENTS.md)，了解目录结构、开发流程与提交流程。仓库使用 Changesets 管理版本与发布，提交功能或修复时请记得补充对应的变更集。
+- 面向 npm 包开发的模板仓库，默认使用 Bun 作为开发与脚本运行环境。
+- 提供完整的 ESM/CJS 导出与类型声明产物，适合直接发布或二次扩展。
+- 内置 CI、Changesets、Lint/格式化、覆盖率校验等质量门槛。
 
-## 特性
+## 核心特性
 
-- TypeScript 严格模式与现代 TS 配置（`strict`、`noUncheckedIndexedAccess` 等）
-- 使用 tsdown 打包产出 CJS/ESM，同时生成类型声明（`.d.ts`）与 Source Map
-- 完整的 ESM/CJS 导出映射（`package.json#exports`、`main`、`module`、`types`）
-- Biome 提供 Lint/格式化与简易 CI 集成
-- Vitest 测试，V8 覆盖率，内置最低 90% 的覆盖率门槛（`bunfig.toml`）
-- Changesets 版本与发布流程，并支持自定义提交消息（`scripts/changeset.commit.ts`）
-- Husky + lint-staged + Commitlint 提交质量门禁（约定式提交）
-- 使用 Volta 固定 Node 版本，确保一致的本地/CI 环境
+- TypeScript 严格模式与现代配置（`strict`、`noUncheckedIndexedAccess` 等）
+- tsdown 打包输出 ESM/CJS、`.d.ts` 与 Source Map
+- 完整导出映射（`package.json#exports`、`main`、`module`、`types`）
+- Biome 提供 Lint/格式化与 CI 集成
+- Vitest + V8 覆盖率，默认覆盖率阈值 ≥ 90%
+- Changesets 版本管理与发布流程，支持自定义提交消息
+- Husky + lint-staged + Commitlint 约定式提交校验
+- Volta 固定 Node 版本，确保本地与 CI 环境一致
 - `attw`（AreTheTypesWrong）导出与类型正确性校验
-- 使用 secretlint 检查敏感信息
+- secretlint 检查敏感信息泄露
 
 ## 环境要求
 
 - Node >= 22（Volta 固定为 22.19.0）
 - Bun >= 1.0.0
-- 包管理器：推荐使用 Bun；如需改用 npm/yarn/pnpm，请保持锁文件与依赖一致。
-- node_modules 布局：Bun 使用 `linker = "isolated"`（pnpm 风格的隔离结构）。
+- 包管理器：推荐使用 Bun；如需改用 npm/yarn/pnpm，请保持锁文件与依赖一致
+- node_modules 布局：Bun 使用 `linker = "isolated"`
 
-## 安装
+## 快速开始
 
 ```bash
 bun install
 ```
 
-## 快速开始（本地演示入口）
+本地演示入口：
 
 ```bash
 bun run src/index.ts
@@ -42,7 +44,7 @@ bun run src/index.ts
 
 ## 作为库使用
 
-当你将本模板产物发布到 npm 后，可按如下方式在其他项目中使用。
+当你将产物发布到 npm 后，可按如下方式引入：
 
 ESM：
 
@@ -50,7 +52,7 @@ ESM：
 import { add, type DemoType } from "create-npm-package";
 
 const result = add(2, 3);
-console.log(result); // 5
+console.log(result);
 
 const user: DemoType = { name: "Tom" };
 ```
@@ -60,7 +62,14 @@ CJS：
 ```js
 const { add } = require("create-npm-package");
 
-console.log(add(2, 3)); // 5
+console.log(add(2, 3));
+```
+
+如果需要按模块导入：
+
+```ts
+import { createGreeter } from "create-npm-package/core";
+import { add } from "create-npm-package/utils";
 ```
 
 ## 常用脚本
@@ -71,7 +80,7 @@ console.log(add(2, 3)); // 5
   - `bun run typecheck`：TypeScript 类型检查
   - `bun run test`：Vitest 全量测试
   - `bun run test:watch`：Vitest 监听模式
-  - `bun run test:coverage`：生成覆盖率报告
+  - `bun run test:coverage`：覆盖率报告
 - 构建与校验
   - `bun run build`：使用 tsdown 打包（CJS/ESM + d.ts + sourcemap → `dist/`）
   - `bun run check:exports`：使用 `attw` 校验导出与类型
@@ -90,18 +99,17 @@ console.log(add(2, 3)); // 5
 .
 ├─ src/
 │  ├─ index.ts          # 库入口与对外导出示例
-│  └─ utils/index.ts    # 示例工具函数（add）
-├─ tests/
-│  └─ utils.test.ts     # Vitest 示例用例
-├─ scripts/
-│  └─ changeset.commit.ts   # Changesets 自定义提交消息生成逻辑
-├─ dist/                 # 构建产物（build 后生成）
-├─ tsdown.config.ts      # 打包配置（含 changeset 构建目标）
-├─ vitest.config.ts      # 测试配置（V8 覆盖率）
-├─ bunfig.toml           # Bun 配置（覆盖率阈值、registry）
-├─ tsconfig.json         # TypeScript 配置（严格模式等）
-├─ package.json          # 脚本、导出映射、引擎/工具声明等
-└─ CHANGELOG.md          # 版本变更记录（由 Changesets 生成）
+│  ├─ core/             # 核心模块示例
+│  └─ utils/            # 工具模块示例
+├─ tests/               # Vitest 用例
+├─ scripts/             # Changesets 辅助脚本
+├─ dist/                # 构建产物（build 后生成）
+├─ tsdown.config.ts     # 打包配置（含 changeset 构建目标）
+├─ vitest.config.ts     # 测试配置（V8 覆盖率）
+├─ bunfig.toml          # Bun 配置（覆盖率阈值、registry）
+├─ tsconfig.json        # TypeScript 配置（严格模式等）
+├─ package.json         # 脚本、导出映射、引擎/工具声明等
+└─ CHANGELOG.md         # 版本变更记录（由 Changesets 生成）
 ```
 
 ## 构建与产物说明
@@ -113,20 +121,11 @@ console.log(add(2, 3)); // 5
   - `index.cjs`（CJS）
   - `index.d.ts` / `index.d.cts`（类型声明）
   - `*.map`（Source Map）
-- 导出映射：见 `package.json#exports`，同时提供 `main/module/types` 字段方便生态工具识别。
-
-## 测试
-
-使用 Vitest，覆盖率提供方为 V8：
-
-```bash
-bun run test
-bun run test:coverage
-```
+- 导出映射：见 `package.json#exports`，并提供 `main/module/types` 字段方便生态工具识别
 
 ## 版本与发布（Changesets）
 
-1. 添加变更集（选择变更类型并填写说明）：
+1. 添加变更集：
 
    ```bash
    bunx changeset add
@@ -144,7 +143,7 @@ bun run test:coverage
    bun run release:publish
    ```
 
-可选：若需自定义 Changesets 的提交消息格式，执行：
+可选：若需自定义 Changesets 的提交消息格式，可执行：
 
 ```bash
 bun run build:changeset
@@ -152,12 +151,16 @@ bun run build:changeset
 
 该命令会将 `scripts/changeset.commit.ts` 编译为 `.changeset/changeset.commit.cjs`，供 Changesets 读取使用。
 
-## FAQ
+## 贡献指南
 
-- Node 版本不满足怎么办？
-  - 请将 Node 升级到 >=22，或使用 Volta/`nvm` 切换到合适版本。仓库使用 Volta 固定为 22.19.0。
-- `attw` 检查失败？
-  - 说明导出或类型存在潜在问题，请根据错误信息调整导出或类型定义，然后重新 `bun run build && bun run check:exports`。
+请阅读 [Repository Guidelines](AGENTS.md)，其中包含目录结构说明、开发流程与提交流程的具体约定。
+
+## 常见问题
+
+- Node 版本不满足？
+  - 请将 Node 升级到 >= 22，或使用 Volta/`nvm` 切换到合适版本。
+- `attw` 校验失败？
+  - 说明导出或类型存在潜在问题，请根据错误信息调整导出或类型定义，然后重新执行 `bun run build && bun run check:exports`。
 
 ## 许可证
 


### PR DESCRIPTION
### Motivation

- Improve clarity and consistency in the Chinese localization of repository templates and README to reduce ambiguity for contributors. 
- Make severity options in the bug report template more descriptive so reporters choose the most appropriate level. 
- Emphasize that the PR checklist should not be removed and clarify the README reference to the repository guidelines.

### Description

- Update ` .github/ISSUE_TEMPLATE/bug_report.yml` to refine the `严重程度` dropdown labels to `轻微影响（可忽略）`, `影响明显（仍有绕过方案）`, and `完全阻断（无法继续）` and add a brief description field for `补充信息`. 
- Update `.github/PULL_REQUEST_TEMPLATE.md` to add a visible “（请勿删除）” hint to the checklist heading and replace checklist items with Chinese guidance including the `bun`/`bunx` commands. 
- Update `README.md` to change wording from “门禁” to “校验”, clarify the link to `AGENTS.md` as the source of repository conventions, and make several small copy improvements in the Chinese localized documentation.

### Testing

- Ran `secretlint` via the configured lint-staged hooks and it passed successfully. 
- No full CI (`bun run ci` / test suite) was executed as part of these documentation-only edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822543a388832f95c09f6c185655e9)